### PR TITLE
Write initial linker functions

### DIFF
--- a/pytest_ethereum/exceptions.py
+++ b/pytest_ethereum/exceptions.py
@@ -12,3 +12,11 @@ class DeployerError(PytestEthereumError):
     """
 
     pass
+
+
+class LinkerError(PytestEthereumError):
+    """
+    Raised when the Linker is unable to link two contract types.
+    """
+
+    pass

--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -1,0 +1,77 @@
+import cytoolz
+from eth_utils import to_canonical_address, to_hex
+from eth_utils.toolz import assoc_in, pipe
+
+from ethpm import Package
+from pytest_ethereum.exceptions import LinkerError
+from pytest_ethereum.utils.linker import (
+    create_deployment_data,
+    create_latest_block_uri,
+    get_deployment_address,
+    insert_deployment,
+)
+
+
+def linker(*args):
+    return _linker(args)
+
+
+@cytoolz.curry
+def _linker(operations, package):
+    return pipe(package, *operations)
+
+
+def deploy(contract_name, *args):
+    """
+    Return a newly created package and contract address.
+    Will deploy the given contract_name, if data exists in package. If
+    a deployment is found on the current w3 instance, it will return that deployment
+    rather than creating a new instance.
+    """
+    return _deploy(contract_name, args)
+
+
+@cytoolz.curry
+def _deploy(contract_name, args, package):
+    deployments = package.deployments
+    if contract_name in deployments:
+        return package, package.deployments[contract_name].address
+
+    # Deploy new instance
+    factory = package.get_contract_factory(contract_name)
+    tx_hash = factory.constructor(*args).transact()
+    tx_receipt = package.w3.eth.waitForTransactionReceipt(tx_hash)
+    address = to_canonical_address(tx_receipt.contractAddress)
+    # Create manifest copy with new deployment instance
+    latest_block_uri = create_latest_block_uri(package.w3, tx_receipt)
+    deployment_data = create_deployment_data(contract_name, address, tx_receipt)
+    manifest = insert_deployment(
+        package, contract_name, deployment_data, latest_block_uri
+    )
+    return Package(manifest, package.w3), address
+
+
+@cytoolz.curry
+def link(contract, linked_type, package_data):
+    """
+    Return a new package, created with a new manifest after applying the linked type
+    reference to the contract factory.
+    """
+    package, _ = package_data
+    deployment_address = get_deployment_address(linked_type, package)
+    unlinked_factory = package.get_contract_factory(contract)
+    if not unlinked_factory.needs_bytecode_linking:
+        raise LinkerError(
+            "Contract factory: {0} does not need bytecode linking, "
+            "so it is not a valid contract type for link()".format(
+                unlinked_factory.__repr__()
+            )
+        )
+    linked_factory = unlinked_factory.link_bytecode({linked_type: deployment_address})
+    # todo replace runtime_bytecode in manifest
+    manifest = assoc_in(
+        package.package_data,
+        ("contract_types", contract, "deployment_bytecode", "bytecode"),
+        to_hex(linked_factory.bytecode),
+    )
+    return Package(manifest, package.w3)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=1,<2",
-        "ethpm>=0.1.3,<2",
+        "ethpm==0.1.3a1",
         "web3[tester]==4.4.1",
         "vyper>=0.1.0b2,<1",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,20 @@ BASE_FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
+def manifest_dir():
+    return Path(__file__).parent / "manifests"
+
+
+@pytest.fixture
 def vyper_project_dir(tmpdir, monkeypatch):
     p = tmpdir.mkdir("vyper_project")
     shutil.copytree(BASE_FIXTURES_DIR, p / "contracts")
     monkeypatch.chdir(str(p))
     return str(p)
+
+
+# LINK REFS
+@pytest.fixture
+def escrow_deployer(solc_deployer, w3, manifest_dir):
+    escrow_manifest_path = manifest_dir / "escrow_manifest.json"
+    return solc_deployer(escrow_manifest_path), w3

--- a/tests/core/test_deployer.py
+++ b/tests/core/test_deployer.py
@@ -95,13 +95,6 @@ def test_safe_math_deployer(safe_math_deployer):
     assert is_address(safe_math_address)
 
 
-# LINK REFS
-@pytest.fixture
-def escrow_deployer(solc_deployer, w3):
-    escrow_manifest_path = MANIFEST_DIR / "escrow_manifest.json"
-    return solc_deployer(escrow_manifest_path), w3
-
-
 def test_escrow_deployer_unlinked(escrow_deployer):
     deployer, w3 = escrow_deployer
     with pytest.raises(DeployerError):

--- a/tests/core/test_linker.py
+++ b/tests/core/test_linker.py
@@ -1,0 +1,35 @@
+from eth_utils import is_address
+import pytest
+
+from ethpm import Package
+from pytest_ethereum.deployer import Deployer
+from pytest_ethereum.exceptions import DeployerError
+from pytest_ethereum.linker import deploy, link, linker
+
+
+@pytest.fixture
+def escrow_deployer(solc_deployer, w3, manifest_dir):
+    escrow_manifest_path = manifest_dir / "escrow_manifest.json"
+    return solc_deployer(escrow_manifest_path), w3
+
+
+def test_linker(escrow_deployer):
+    # todo test multiple links in one type
+    deployer, w3 = escrow_deployer
+    assert isinstance(deployer, Deployer)
+    with pytest.raises(DeployerError):
+        deployer.deploy("Escrow")
+
+    escrow_strategy = linker(
+        deploy("SafeSendLib"),
+        link("Escrow", "SafeSendLib"),
+        deploy("Escrow", w3.eth.accounts[0]),
+    )
+    assert hasattr(escrow_strategy, "__call__")
+    deployer.register_strategy("Escrow", escrow_strategy)
+    escrow_deployer = deployer.deploy("Escrow")
+    linked_escrow_package, escrow_address = escrow_deployer
+    assert isinstance(linked_escrow_package, Package)
+    assert is_address(escrow_address)
+    linked_escrow_factory = linked_escrow_package.get_contract_factory("Escrow")
+    assert linked_escrow_factory.needs_bytecode_linking is False

--- a/tests/core/utils/test_linker_utils.py
+++ b/tests/core/utils/test_linker_utils.py
@@ -1,0 +1,85 @@
+from eth_utils import remove_0x_prefix, to_hex
+from eth_utils.toolz import assoc
+import pytest
+
+from ethpm.utils.chains import create_block_uri, get_chain_id
+from pytest_ethereum.exceptions import LinkerError
+from pytest_ethereum.utils.linker import (
+    contains_matching_uri,
+    insert_deployment,
+    pluck_matching_uri,
+)
+
+
+@pytest.fixture
+def chain_setup(w3):
+    old_chain_id = remove_0x_prefix(to_hex(get_chain_id(w3)))
+    block_hash = remove_0x_prefix(to_hex(w3.eth.getBlock("earliest").hash))
+    old_chain_uri = "blockchain://{0}/block/{1}".format(old_chain_id, block_hash)
+    match_data = {
+        old_chain_uri: {"x": "x"},
+        "blockchain://{0}/block/{1}".format("1234", block_hash): {"x": "x"},
+    }
+    no_match_data = {
+        "blockchain://56775ac59d0774e6b603a79c4218efeb5653b99ba0ff14db983bac2662251a8a/block/{0}".format(  # noqa: E501
+            block_hash
+        ): {
+            "x": "x"
+        }
+    }
+    return w3, match_data, no_match_data, old_chain_uri
+
+
+def test_pluck_matching_uri(chain_setup):
+    w3, match_data, no_match_data, old_chain_uri = chain_setup
+
+    assert pluck_matching_uri(match_data, w3) == old_chain_uri
+    with pytest.raises(LinkerError):
+        assert pluck_matching_uri(no_match_data, w3)
+
+
+def test_contains_matching_uri(chain_setup):
+    w3, match_data, no_match_data, _ = chain_setup
+
+    assert contains_matching_uri(match_data, w3) is True
+    assert contains_matching_uri(no_match_data, w3) is False
+
+
+def test_insert_deployment(escrow_deployer):
+    deployer, w3 = escrow_deployer
+    escrow_package = deployer.package
+    init_deployment_data = {
+        "contract_type": "Escrow",
+        "address": "0x",
+        "transaction": "0x",
+        "block": "0x",
+    }
+    new_deployment_data = {
+        "contract_type": "Escrow",
+        "address": "0x123",
+        "transaction": "0x123",
+        "block": "0x123",
+    }
+    genesis_hash = to_hex(get_chain_id(w3))
+    w3.testing.mine(1)
+    init_block_hash = to_hex(w3.eth.getBlock("latest")["hash"])
+    init_block_uri = create_block_uri(genesis_hash, init_block_hash)
+    alt_block_uri = init_block_uri[:15] + "yxz123" + init_block_uri[21:]
+    init_block_deployment_data = {
+        init_block_uri: {"Other": {"x": "x"}, "Escrow": init_deployment_data},
+        alt_block_uri: {"alt": {"x": "x"}},
+    }
+    w3.testing.mine(1)
+    new_block_hash = to_hex(w3.eth.getBlock("latest")["hash"])
+    new_block_uri = create_block_uri(genesis_hash, new_block_hash)
+    escrow_package.package_data = assoc(
+        escrow_package.package_data, "deployments", init_block_deployment_data
+    )
+    updated_manifest = insert_deployment(
+        escrow_package, "Escrow", new_deployment_data, new_block_uri
+    )
+    expected_deployments_data = {
+        new_block_uri: {"Other": {"x": "x"}, "Escrow": new_deployment_data},
+        alt_block_uri: {"alt": {"x": "x"}},
+    }
+    assert updated_manifest["deployments"] == expected_deployments_data


### PR DESCRIPTION
THIS PR RELIES ON https://github.com/ethpm/py-ethpm/pull/104 to be approved, merged, and released before it will pass CI.

## What was wrong?
The `deployer` tool was incapable of deploying contract factories with link references. 

## How was it fixed?
Wrote a `linker` tool that let's the user build a linking strategy for a contract factory, and register that strategy to a `deployer`.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45696319-95b7d300-bb20-11e8-8715-2b46110d0ff0.png)

