### PR TITLE
Write twig_deployer fixture

### DIFF
--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -59,18 +59,15 @@ def _deploy(contract_name: str, args: Any, package: Package) -> Tuple[Package, A
     manifest = insert_deployment(
         package, contract_name, deployment_data, latest_block_uri
     )
-    return Package(manifest, package.w3), address
+    return Package(manifest, package.w3)
 
 
 @cytoolz.curry
-def link(
-    contract: str, linked_type: str, package_data: Tuple[Package, Address]
-) -> Package:
+def link(contract: str, linked_type: str, package: Package) -> Package:
     """
     Return a new package, created with a new manifest after applying the linked type
     reference to the contract factory.
     """
-    package, _ = package_data
     deployment_address = get_deployment_address(linked_type, package)
     unlinked_factory = package.get_contract_factory(contract)
     if not unlinked_factory.needs_bytecode_linking:

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=1,<2",
-        "ethpm==0.1.3a6",
+        "ethpm==0.1.3a7",
         "web3[tester]==4.4.1",
         "vyper>=0.1.0b2,<1",
     ],

--- a/tests/core/test_linker.py
+++ b/tests/core/test_linker.py
@@ -1,4 +1,3 @@
-from eth_utils import is_address
 import pytest
 
 from ethpm import ASSETS_DIR, Package
@@ -27,9 +26,7 @@ def test_linker(escrow_deployer):
     )
     assert hasattr(escrow_strategy, "__call__")
     deployer.register_strategy("Escrow", escrow_strategy)
-    escrow_deployer = deployer.deploy("Escrow")
-    linked_escrow_package, escrow_address = escrow_deployer
+    linked_escrow_package = deployer.deploy("Escrow")
     assert isinstance(linked_escrow_package, Package)
-    assert is_address(escrow_address)
     linked_escrow_factory = linked_escrow_package.get_contract_factory("Escrow")
     assert linked_escrow_factory.needs_bytecode_linking is False


### PR DESCRIPTION
## What was wrong?
Some adjustments were needed to use the `Deployer` in `twig`

- Made the `TWIG_GLOB` == 'v.py' since that's the extension i'm using for vyper files as my editor formats those as python, but blank if '.vy'



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/46543803-a5e8e580-c876-11e8-9131-4a7bf0087215.png)

