### PR TITLE
Refactor insert deployments for better usability in py-ethpm

### DIFF
--- a/pytest_ethereum/_utils/linker.py
+++ b/pytest_ethereum/_utils/linker.py
@@ -7,35 +7,40 @@ from web3 import Web3
 from ethpm import Package
 from ethpm.typing import URI, Address, Manifest
 from ethpm.utils.chains import (
-    check_if_chain_matches_chain_uri,
     create_block_uri,
     get_genesis_block_hash,
+    parse_BIP122_uri,
 )
 from pytest_ethereum.exceptions import LinkerError
 from pytest_ethereum.typing import TxReceipt
 
 
-def pluck_matching_uri(deployment_data: Dict[str, Dict[str, str]], w3: Web3) -> URI:
+def pluck_matching_uri(deployment_data: Dict[str, Dict[str, str]], new_uri: URI) -> URI:
     """
     Return any blockchain uri that matches w3-connected chain, if one
     is present in the deployment data keys.
     """
+    new_genesis, _, _ = parse_BIP122_uri(new_uri)
     for uri in deployment_data.keys():
-        if check_if_chain_matches_chain_uri(w3, uri):
+        old_genesis, _, _ = parse_BIP122_uri(uri)
+        if new_genesis == old_genesis:
             return uri
     raise LinkerError(
-        f"No matching blockchain URI found in deployment_data: {list(deployment_data.keys())}, "
-        "for w3 instance: {w3.__repr__()}."
+        f"No matching blockchain URI found in deployment_data: {list(deployment_data.keys())}."
     )
 
 
-def contains_matching_uri(deployment_data: Dict[str, Dict[str, str]], w3: Web3) -> bool:
+def contains_matching_uri(
+    deployment_data: Dict[str, Dict[str, str]], new_uri: URI
+) -> bool:
     """
-    Returns true if any blockchain uri in deployment data matches
-    w3-connected chain.
+    Return a bool indicating whether or not a matching blockchain URI is found in
+    the deployment data.
     """
+    new_genesis, _, _ = parse_BIP122_uri(new_uri)
     for uri in deployment_data.keys():
-        if check_if_chain_matches_chain_uri(w3, uri):
+        old_genesis, _, _ = parse_BIP122_uri(uri)
+        if new_genesis == old_genesis:
             return True
     return False
 
@@ -50,19 +55,21 @@ def create_latest_block_uri(w3: Web3, tx_receipt: TxReceipt) -> URI:
 
 
 def insert_deployment(
-    package: Package,
+    manifest: Manifest,
+    latest_block_uri: URI,
     deployment_name: str,
     deployment_data: Dict[str, str],
-    latest_block_uri: URI,
 ) -> Manifest:
     """
-    Returns a new manifest. If a matching chain uri is found in the old manifest, it will
-    update the chain uri along with the new deployment data. If no match, it will simply add
-    the new chain uri and deployment data.
+    Returns a manifest updated with the deployment. If a matching chain uri is found in the old
+    manifest, it will update the chain uri along with the new deployment data. If no match,
+    it will simply add the new chain uri and deployment data.
     """
-    old_deployments_data = package.manifest.get("deployments")
-    if old_deployments_data and contains_matching_uri(old_deployments_data, package.w3):
-        old_chain_uri = pluck_matching_uri(old_deployments_data, package.w3)
+    old_deployments_data = manifest.get("deployments")
+    if old_deployments_data and contains_matching_uri(
+        old_deployments_data, latest_block_uri
+    ):
+        old_chain_uri = pluck_matching_uri(old_deployments_data, latest_block_uri)
         old_deployments_chain_data = old_deployments_data[old_chain_uri]
         # Replace specific on-chain deployment (i.e. deployment_name)
         new_deployments_chain_data_init = dissoc(
@@ -80,12 +87,10 @@ def insert_deployment(
             **new_deployments_data_init,
             **{latest_block_uri: new_deployments_chain_data},
         }
-        return assoc(package.manifest, "deployments", new_deployments_data)
+        return assoc(manifest, "deployments", new_deployments_data)
 
     return assoc_in(
-        package.manifest,
-        ("deployments", latest_block_uri, deployment_name),
-        deployment_data,
+        manifest, ("deployments", latest_block_uri, deployment_name), deployment_data
     )
 
 

--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -57,7 +57,7 @@ def _deploy(
         contract_name, address, tx_receipt, factory.linked_references
     )
     manifest = insert_deployment(
-        package, contract_name, deployment_data, latest_block_uri
+        package.manifest, latest_block_uri, contract_name, deployment_data
     )
     return Package(manifest, package.w3)
 


### PR DESCRIPTION
## What was wrong?
`insert_deployments` needed some adjustments so it could also be used in `py-ethpm`'s `builder` tool

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/47431550-53775680-d79c-11e8-90d5-a522076f7322.png)
