### PR TITLE
Add `run_python` to linker fns

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -75,7 +75,7 @@ Linker
 
 If a contract factory requires linking, you must register a "strategy" for a particular contract factory with the deployer. It is up to you to design an appropriate strategy for a contract factory. 
 
-Two ``linker`` functions are made available:
+Three ``linker`` functions are made available:
 
 .. py:method:: deploy(contract_name, *args=None)
 
@@ -84,6 +84,11 @@ Two ``linker`` functions are made available:
 .. py:method:: link(contract_name, linked_type)
 
    Links a `contract_name` to a `linked_type`. The `linked_type` must have already been deployed.
+
+.. py:method:: run_python(callback_fn)
+
+   Calls any user-defined `callback_fn` on the contracts available in the active `Package`. This can be used to call specific functions on a contract if they are part of the setup. Returns the original, unmodified `Package` that was passed in.
+
 
 For example, the `Escrow` contract factory requires linking to an instance of the `SafeSendLib` before an `Escrow` contract instance can be deployed. This is how you would set up a strategy for `Escrow`
 

--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -40,6 +40,7 @@ def deploy(
 def _deploy(
     contract_name: str, args: Any, transaction: Dict[str, Any], package: Package
 ) -> Tuple[Package, Address]:
+    package.w3.testing.mine(1)
     # Deploy new instance
     factory = package.get_contract_factory(contract_name)
     if not factory.linked_references and factory.unlinked_references:
@@ -83,3 +84,13 @@ def link(contract: str, linked_type: str, package: Package) -> Package:
         to_hex(linked_factory.bytecode),
     )
     return Package(manifest, package.w3)
+
+
+@cytoolz.curry
+def run_python(callback_fn: Callable[..., None], package: Package) -> Package:
+    """
+    Return the unmodified package, after performing any user-defined callback function on
+    the contracts in the package.
+    """
+    callback_fn(package)
+    return package

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     url='https://github.com/ethereum/pytest-ethereum',
     include_package_data=True,
     install_requires=[
+        "eth-abi>=1.2.2,<2",
         "eth-utils>=1,<2",
         "ethpm>=0.1.4a1,<1",
         'web3[tester]>=4.7,<5',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from ethpm import ASSETS_DIR
 
 BASE_FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+pytest_plugins = ["pytest_ethereum.plugins"]
+
 
 @pytest.fixture
 def manifest_dir():


### PR DESCRIPTION
## What was wrong?
Linker tool would benefit from `do_callback` which allows to user to define any aribtrary `callback_fn` that can call functions on deployed contracts as part of the setup. 

## How was it fixed?
`do_callback` function performs the given `callback_fn` on the `Package` that's being passed through the linker fns. However, even if the `callback_fn` performs some adjustments on the `Package` - it is the original, unmodified `Package` that is passed onto the next linker fn. `do_callback` is fairly simple now, but will likely evolve to accommodate frequent use-cases down the road.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/48567912-2418bd00-e8f6-11e8-990a-ad64d1f1190c.png)

