### PR TITLE
Update ethpm.typing to eth_typing

### DIFF
--- a/pytest_ethereum/_utils/linker.py
+++ b/pytest_ethereum/_utils/linker.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Iterable, List, Tuple
 
+from eth_typing import URI, Address, Manifest
 from eth_utils import to_canonical_address, to_dict, to_hex, to_list
 from eth_utils.toolz import assoc, assoc_in, dissoc
 from ethpm import Package
-from ethpm.typing import URI, Address, Manifest
 from ethpm.utils.chains import (
     check_if_chain_matches_chain_uri,
     create_block_uri,

--- a/pytest_ethereum/deployer.py
+++ b/pytest_ethereum/deployer.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Tuple  # noqa: F401
 
 from ethpm import Package
-from ethpm.typing import Address
+from eth_typing import Address
 
 from pytest_ethereum.exceptions import DeployerError
 from pytest_ethereum.linker import deploy, linker

--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Callable, Dict, Tuple
 
+from eth_typing import Address
 from eth_utils import to_canonical_address, to_checksum_address, to_hex
 from eth_utils.toolz import assoc_in, curry, pipe
 from ethpm import Package
-from ethpm.typing import Address
 
 from pytest_ethereum._utils.linker import (
     create_deployment_data,


### PR DESCRIPTION
## What was wrong?
`ethpm.typing` has been deprecated in favor of `eth_typing`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/57287472-e2ecb300-70b7-11e9-8391-0adc23331049.png)

