### PR TITLE
Remove ethpm.typing dependency

### DIFF
--- a/pytest_ethereum/_utils/linker.py
+++ b/pytest_ethereum/_utils/linker.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Iterable, List, Tuple
 
+from eth_typing import URI, Address, Manifest
 from eth_utils import to_canonical_address, to_dict, to_hex, to_list
 from eth_utils.toolz import assoc, assoc_in, dissoc
 from ethpm import Package
-from ethpm.typing import URI, Address, Manifest
 from ethpm.utils.chains import (
     check_if_chain_matches_chain_uri,
     create_block_uri,
@@ -15,7 +15,7 @@ from pytest_ethereum.exceptions import LinkerError
 from pytest_ethereum.typing import TxReceipt
 
 
-def pluck_matching_uri(deployment_data: Dict[str, Dict[str, str]], w3: Web3) -> URI:
+def pluck_matching_uri(deployment_data: Dict[URI, Dict[str, str]], w3: Web3) -> URI:
     """
     Return any blockchain uri that matches w3-connected chain, if one
     is present in the deployment data keys.

--- a/pytest_ethereum/deployer.py
+++ b/pytest_ethereum/deployer.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Tuple  # noqa: F401
 
+from eth_typing import Address
 from ethpm import Package
-from ethpm.typing import Address
 
 from pytest_ethereum.exceptions import DeployerError
 from pytest_ethereum.linker import deploy, linker

--- a/pytest_ethereum/linker.py
+++ b/pytest_ethereum/linker.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Callable, Dict, Tuple
 
+from eth_typing import Address
 from eth_utils import to_canonical_address, to_checksum_address, to_hex
 from eth_utils.toolz import assoc_in, curry, pipe
 from ethpm import Package
-from ethpm.typing import Address
 
 from pytest_ethereum._utils.linker import (
     create_deployment_data,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import pytest
 
 TESTS_DIR = Path(__file__).parent
 
-pytest_plugins = ["pytest_ethereum.plugins"]
-
 
 @pytest.fixture
 def manifest_dir():


### PR DESCRIPTION
## What was wrong?
`ethpm.typing` is being deprecated in favor of `eth_typing`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/60051417-329b3400-9690-11e9-905a-734b48362bc5.png)
